### PR TITLE
Develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ Produces: ```app/dashboard/UserCtrl.js```:
  		vm = this;
  
  		vm.testFunction = testFunction;
- 
+
+    /////////////////////
+     
  		function testFunction () {
  			console.info('This is a test function');
  		}

--- a/controller/index.js
+++ b/controller/index.js
@@ -7,9 +7,15 @@ var NgSuperGenerator = yeoman.generators.NamedBase.extend({
   initializing: function () {
     utils.setModuleComponentNames(this, this.name);
     this.component = this._.capitalize(this.component) + 'Ctrl';
-    this.log('You called the ng-super subgenerator with the argument ' + this.name + '.');
+    this.log('Controller Sub-Generator invoked');
   },
-
+  module: function(){
+    if(utils.doesModuleExist(this, this.module)){
+      this.composeWith('ng-super:feature', {
+        args:[this.module]
+      });
+    };
+  },
   file: function () {
     var templatePath = utils.getComponentsTemplatePath('controller.js');
     var filePath = utils.getComponentFilePath(this.module, this.component);

--- a/directive/index.js
+++ b/directive/index.js
@@ -6,9 +6,15 @@ var yeoman = require('yeoman-generator');
 var NgSuperGenerator = yeoman.generators.NamedBase.extend({
   initializing: function () {
     utils.setModuleComponentNames(this, this.name);
-    this.log('You called the ng-super subgenerator with the argument ' + this.name + '.');
+    this.log('Directive Sub-Generator invoked');
   },
-
+  module: function(){
+    if(utils.doesModuleExist(this, this.module)){
+      this.composeWith('ng-super:feature', {
+        args:[this.module]
+      });
+    };
+  },
   file: function () {
     var templatePath = utils.getComponentsTemplatePath('directive.js');
     var filePath = utils.getComponentFilePath(this.module, this.component);

--- a/factory/index.js
+++ b/factory/index.js
@@ -6,9 +6,15 @@ var yeoman = require('yeoman-generator');
 var NgSuperGenerator = yeoman.generators.NamedBase.extend({
   initializing: function () {
     utils.setModuleComponentNames(this, this.name);
-    this.log('You called the ng-super subgenerator with the argument ' + this.name + '.');
+    this.log('Factory Sub-Generator invoked');
   },
-
+  module: function(){
+    if(utils.doesModuleExist(this, this.module)){
+      this.composeWith('ng-super:feature', {
+        args:[this.module]
+      });
+    };
+  },
   file: function () {
     var templatePath = utils.getComponentsTemplatePath('factory.js');
     var filePath = utils.getComponentFilePath(this.module, this.component);

--- a/feature/index.js
+++ b/feature/index.js
@@ -5,7 +5,7 @@ var yeoman = require('yeoman-generator');
 
 var NgSuperGenerator = yeoman.generators.NamedBase.extend({
   initializing: function () {
-    this.log('You called the ng-super subgenerator with the argument ' + this.name + '.');
+    this.log('Feature Sub-Generator invoked');
     this.module = this.name;
   },
 

--- a/templates/components/_controller.js
+++ b/templates/components/_controller.js
@@ -12,6 +12,8 @@
 
 		vm.testFunction = testFunction;
 
+    /////////////////////
+
 		function testFunction () {
 			console.info('This is a test function');
 		}

--- a/utils.js
+++ b/utils.js
@@ -9,7 +9,8 @@ module.exports = {
   getGruntTasksTemplatePath: getGruntTasksTemplatePath,
   setModuleComponentNames: setModuleComponentNames,
   addScriptTagToIndex: addScriptTagToIndex,
-  addModuleNameToAppModule: addModuleNameToAppModule
+  addModuleNameToAppModule: addModuleNameToAppModule,
+  doesModuleExist: doesModuleExist
 };
 
 var basePath = '../../templates/';
@@ -126,4 +127,19 @@ function insertSpaces(value, count){
   }
 
   return value;
+}
+
+function doesModuleExist(self, moduleName){
+  var pathToModuleFile = appFolderPath + moduleName +'/' +moduleName+ '.module.js';
+  var shouldCreateModuleFile = true;
+  try{
+    var moduleFile = self.readFileAsString(pathToModuleFile);
+    if(moduleFile.length > 0){
+      shouldCreateModuleFile = false;
+    }
+  }
+  catch(e){
+    console.log(moduleName + ' module not found');
+  }
+  return shouldCreateModuleFile;
 }


### PR DESCRIPTION
if a feature module does not exist, and the user is trying to create a component, say, a controller, the sub-generator should create the module file itself. This composition has been added in this pull request.