### PR TITLE
resolved issue#9

### DIFF
--- a/templates/root/_index.html
+++ b/templates/root/_index.html
@@ -20,11 +20,11 @@
   <script src="bower_components/angular-bootstrap/ui-bootstrap.js"></script>
   <script src="bower_components/lodash/dist/lodash.js"></script>
   <script src="bower_components/restangular/dist/restangular.js"></script>
-  <script src="app.module.js"></script>
   <script src="core/core.module.js"></script>
+  <script src="common/common.module.js"></script>
+  <script src="app.module.js"></script>
   <script src="core/restangularConfig.js"></script>
   <script src="core/routerConfig.js"></script>
-  <script src="common/common.module.js"></script>
   <script src="welcome/welcome.module.js"></script>
   <script src="welcome/WelcomeCtrl.js"></script>
   <!-- endbuild -->

--- a/utils.js
+++ b/utils.js
@@ -67,7 +67,7 @@ function setModuleComponentNames(retValObject, dottedName){
 
 function addScriptTagToIndex(self, scriptPath){
   var pathToIndexFile = appFolderPath + 'index.html';
-  var indexReplacementTag = '<!-- endbuild -->';
+  var indexReplacementTag = scriptPath.indexOf('module') !== -1? '<script src="app.module.js"></script>' : '<!-- endbuild -->';
   var indexFile = self.readFileAsString(pathToIndexFile);
   var splitIndexFile = indexFile.split('\n');
   var indexOfReplacementTag = indexOfTag(splitIndexFile, indexReplacementTag);


### PR DESCRIPTION
Resolved Issue#9. Script tags for modules are now inserted at top of app.module.js tag. This will always cause a module to be registered before it is accessed.